### PR TITLE
improve symantic highlighting and add vscode support

### DIFF
--- a/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
+++ b/packages/pyright-internal/src/languageService/semanticTokensProvider.ts
@@ -21,11 +21,14 @@ export const tokenTypes: string[] = [
     SemanticTokenTypes.decorator,
     SemanticTokenTypes.property,
     SemanticTokenTypes.namespace,
+    SemanticTokenTypes.variable,
+    SemanticTokenTypes.type,
 ];
 export const tokenModifiers: string[] = [
     SemanticTokenModifiers.definition,
     SemanticTokenModifiers.declaration,
     SemanticTokenModifiers.async,
+    SemanticTokenModifiers.readonly,
 ];
 
 export const SemanticTokensProviderLegend = {


### PR DESCRIPTION
hello. i maintain [basedpyright](https://github.com/detachhead/basedpyright) which fixes a bunch of issues with pyright as well as re-implements some features that were previously exclusive to pylance.

i hope you don't mind, i intend to merge the changes from your fork into mine as well as some additional improvements i made (https://github.com/DetachHead/basedpyright/pull/129). this PR contains those additional changes:

- updated the vscode extension to use the inlay hints and semantic highlighting
- updated the semantic highlighting to work on more symbols. as far as i'm aware it now matches pylance's syntax highlighting

i'd be happy to to work together improving pyright under one project. if you're interested i can add you as a member on my repo